### PR TITLE
보드 생성 컴포넌트 추가

### DIFF
--- a/src/components/BoardFormToast.tsx
+++ b/src/components/BoardFormToast.tsx
@@ -1,0 +1,28 @@
+import styled, { keyframes } from 'styled-components';
+
+export default function BoardFormToast() {
+  return <StWrapper>글자 수가 넘쳤어요!</StWrapper>;
+}
+
+const toastAnimation = keyframes`
+0% {
+    opacity: 100%;
+}
+100% {
+    opacity: 0%;
+}
+`;
+
+const StWrapper = styled.div`
+  position: absolute;
+  top: 298px;
+  background-color: #111111;
+  color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 253px;
+  height: 58px;
+  border-radius: 34px;
+  animation: ${toastAnimation} 1s linear 1;
+`;

--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -11,7 +11,7 @@ export default function BoardForm() {
 
   const [isActive, setIsActive] = useState<boolean>(false);
   const [isToast, setIsToast] = useState<boolean>(false);
-  const [input, setInput] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
 
   useEffect(() => {
     if (isToast) {
@@ -19,17 +19,17 @@ export default function BoardForm() {
     }
   }, [isToast]);
 
-  const changeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length > 5) {
       setIsToast(true);
       return;
     }
-    e.target.value.length > 0 ? setIsActive(true) : setIsActive(false);
-    setInput(e.target.value);
+    setIsActive(e.target.value.length > 0);
+    setTitle(e.target.value);
   };
 
   const goBoard = () => {
-    if (input.length > 0) navigate(`/board/id들어갈곳`);
+    if (title.length > 0) navigate(`/board/id들어갈곳`);
   };
 
   const goBack = () => {
@@ -47,7 +47,7 @@ export default function BoardForm() {
       </StHeaderWrapper>
       <StFormWrapper>
         <StFormTitle>보드 이름</StFormTitle>
-        <StInput type="text" placeholder="추가" onChange={changeInput} value={input} />
+        <StInput type="text" placeholder="추가" onChange={handleChangeInput} value={title} />
       </StFormWrapper>
       {isToast && <BoardFormToast />}
     </StWrapper>

--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcBack } from '../assets/icons';
 import BoardFormToast from '../components/BoardFormToast';
+import { COLOR } from '../styles/color';
 import { FONT_STYLES } from '../styles/fonts/font';
 
 export default function BoardForm() {
@@ -81,8 +82,8 @@ const StCreateButton = styled.button<{ isActive: boolean }>`
   top: 23px;
   right: 10px;
   border-radius: 16px;
-  background-color: ${(props) => (props.isActive ? '#D32D2F' : '#CDCDCD')};
-  color: ${(props) => (props.isActive ? '#FFFFFF' : '#767676')};
+  background-color: ${(props) => (props.isActive ? `${COLOR.RED}` : `${COLOR.GRAY_200}`)};
+  color: ${(props) => (props.isActive ? `${COLOR.WHITE}` : `${COLOR.GRAY_100}`)};
   border: 0;
   outline: 0;
   &:hover {
@@ -93,8 +94,8 @@ const StCreateButton = styled.button<{ isActive: boolean }>`
 const StFormWrapper = styled.div`
   width: calc(100% - 20px);
   height: 85px;
-  border-top: 1px solid #cdcdcd;
-  border-bottom: 1px solid #cdcdcd;
+  border-top: 1px solid ${COLOR.GRAY_200};
+  border-bottom: 1px solid ${COLOR.GRAY_200};
   padding: 11px 14px;
   box-sizing: border-box;
 `;
@@ -111,7 +112,7 @@ const StInput = styled.input`
   padding-left: 11px;
   ${FONT_STYLES.H3_BOLD}
   &::placeholder {
-    color: #cdcdcd;
+    color: ${COLOR.GRAY_200};
   }
 `;
 

--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -1,3 +1,126 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { IcBack } from '../assets/icons';
+import BoardFormToast from '../components/BoardFormToast';
+import { FONT_STYLES } from '../styles/fonts/font';
+
 export default function BoardForm() {
-  return <div>BoardForm 화면</div>;
+  const navigate = useNavigate();
+
+  const [isActive, setIsActive] = useState<boolean>(false);
+  const [isToast, setIsToast] = useState<boolean>(false);
+  const [input, setInput] = useState<string>('');
+
+  useEffect(() => {
+    if (isToast) {
+      setTimeout(() => setIsToast(false), 1000);
+    }
+  }, [isToast]);
+
+  const changeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length > 5) {
+      setIsToast(true);
+    }
+    e.target.value.length > 0 ? setIsActive(true) : setIsActive(false);
+    setInput(e.target.value);
+  };
+
+  const goBoard = () => {
+    if (input.length > 0) navigate(`/board/id들어갈곳`);
+  };
+
+  const goBack = () => {
+    navigate('/');
+  };
+
+  return (
+    <StWrapper>
+      <StHeaderWrapper>
+        <StIcBack onClick={goBack} />
+        <StHeaderTitle>보드 만들기</StHeaderTitle>
+        <StCreateButton isActive={isActive} onClick={goBoard}>
+          만들기
+        </StCreateButton>
+      </StHeaderWrapper>
+      <StFormWrapper>
+        <StFormCover>
+          <StFormTitle>보드 이름</StFormTitle>
+          <StInput type="text" placeholder="추가" onChange={changeInput} value={input} />
+        </StFormCover>
+      </StFormWrapper>
+      {isToast && <BoardFormToast />}
+    </StWrapper>
+  );
 }
+
+const StWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StHeaderWrapper = styled.div`
+  width: 100%;
+  height: 72px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0px 10px;
+`;
+
+const StHeaderTitle = styled.b`
+  ${FONT_STYLES.B1_BOLD}
+`;
+
+const StCreateButton = styled.button<{ isActive: boolean }>`
+  width: 64px;
+  height: 32px;
+  position: absolute;
+  top: 23px;
+  right: 10px;
+  border-radius: 16px;
+  background-color: ${(props) => (props.isActive ? '#D32D2F' : '#CDCDCD')};
+  color: ${(props) => (props.isActive ? '#FFFFFF' : '#767676')};
+  border: 0;
+  outline: 0;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const StFormWrapper = styled.div`
+  width: 100%;
+  height: 85px;
+`;
+
+const StFormCover = styled.div`
+  margin: 0px 10px;
+  border-top: 1px solid #cdcdcd;
+  border-bottom: 1px solid #cdcdcd;
+  padding: 11px 14px;
+`;
+
+const StFormTitle = styled.b`
+  ${FONT_STYLES.B3_REGULAR}
+`;
+
+const StInput = styled.input`
+  width: 100%;
+  height: 49px;
+  border: 0;
+  outline: 0;
+  padding-left: 11px;
+  ${FONT_STYLES.H3_BOLD}
+  &::placeholder {
+    color: #cdcdcd;
+  }
+`;
+
+const StIcBack = styled(IcBack)`
+  position: absolute;
+  top: 23px;
+  left: 10px;
+`;

--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -21,6 +21,7 @@ export default function BoardForm() {
   const changeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length > 5) {
       setIsToast(true);
+      return;
     }
     e.target.value.length > 0 ? setIsActive(true) : setIsActive(false);
     setInput(e.target.value);
@@ -44,10 +45,8 @@ export default function BoardForm() {
         </StCreateButton>
       </StHeaderWrapper>
       <StFormWrapper>
-        <StFormCover>
-          <StFormTitle>보드 이름</StFormTitle>
-          <StInput type="text" placeholder="추가" onChange={changeInput} value={input} />
-        </StFormCover>
+        <StFormTitle>보드 이름</StFormTitle>
+        <StInput type="text" placeholder="추가" onChange={changeInput} value={input} />
       </StFormWrapper>
       {isToast && <BoardFormToast />}
     </StWrapper>
@@ -92,15 +91,12 @@ const StCreateButton = styled.button<{ isActive: boolean }>`
 `;
 
 const StFormWrapper = styled.div`
-  width: 100%;
+  width: calc(100% - 20px);
   height: 85px;
-`;
-
-const StFormCover = styled.div`
-  margin: 0px 10px;
   border-top: 1px solid #cdcdcd;
   border-bottom: 1px solid #cdcdcd;
   padding: 11px 14px;
+  box-sizing: border-box;
 `;
 
 const StFormTitle = styled.b`


### PR DESCRIPTION
## ⛓ Related Issues
- close #22 

## 📋 작업 내용
- [x] 보드 생성 컴포넌트 추가
- [x] 보드 생성 글자수 토스트 추가

## 📌 PR Point
- 보드 폼을 스타일로 감싼 부분을 div를 두개를 줬는데, 준 이유는 하나로 감싸니 margin이 먹지 않았습니다! (위 아래 구분선이 살짝 간격이 있습니다.) 저 부분을 간략화 할 수 있는 방법이 있을 까요? StFormWrapper 와 StCoverWrapper 입니다!
- 일단 글자수가 5개가 넘으면, 토스트가 나타나게 했는데 보통은 글자수 5개를 넘으면 input을 다시 비워주는게 좋을까요? 
아니면 입력을 못하게 막아버리는게 좋을까요? 현재는 5개가 넘어도 계속 입력할 수 있고, 입력할 때 마다 토스트가 나타나게 됩니다!

--> 리뷰 반영
- 첫번째는 width를 calc 속성을 줘서 해결했습니다!
- 두번째는 length가 5를 초과하면 input state에 변화를 주지 않고 return 을 해버리도록 변경했습니다!!

## 👀 스크린샷 / GIF / 링크
<img width="355" alt="스크린샷 2022-05-27 오전 9 49 59" src="https://user-images.githubusercontent.com/42725903/170607609-90a53190-c1ad-4a7c-bb28-7936dc142263.png">

https://user-images.githubusercontent.com/42725903/170607704-9f27ad9b-d959-42c0-a857-957d05c1a3d9.mov


## 🔬 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
