### PR TITLE
데이터 프로바이더 만들고 보드 조회에 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/styled-components": "^5.1.25",
+    "axios": "^0.27.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,7 +1,6 @@
 export { ReactComponent as IcSearch } from './icon_search.svg';
 export { default as icPlus } from './icon_plus.svg';
 export { ReactComponent as IcPlus } from './icon_plus.svg';
-export { default as icPlus } from './icon_plus.svg';
 export { ReactComponent as IcSearchGray1 } from './icon_search_gray_1.svg';
 export { ReactComponent as IcPlusGray1 } from './icon_plus_gray_1.svg';
 export { default as icSetting } from './icon_setting.svg';

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -4,17 +4,34 @@ import { FONT_STYLES } from '../styles/font';
 import { COLOR } from '../styles/color';
 import { MOCK_DATA } from '../services/mock/data';
 import useToast from '../hooks/useToast';
+import { useEffect } from 'react';
+import { useState } from 'react';
+import { BoardInfo } from '../types';
+import { useNavigate, useParams } from 'react-router-dom';
+import { service } from '../services';
 
 export default function Board() {
   const { showToast } = useToast();
+  const [boardInfo, setBoardInfo] = useState<Pick<BoardInfo, 'title' | 'savedTime'> | undefined>();
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const getBoardInfo = async () => {
+    if (!id) return navigate('/');
+    const response = await service.getBoardDetail(id);
+    response && setBoardInfo(response);
+  };
+  useEffect(() => {
+    getBoardInfo();
+  }, []);
   return (
     <StWrapper>
       <button onClick={() => showToast('보드를 만들었습니다!', 'COMPLETE')}>토스트 test</button>
       <StHeader>
         <IcBack /> <IcViewMore />
       </StHeader>
-      <StTitle>바닷가</StTitle>
-      <StCreateAt>방금</StCreateAt>
+      <StTitle>{boardInfo?.title}</StTitle>
+      <StCreateAt>{boardInfo?.savedTime}</StCreateAt>
       <StProfile>
         <img src={MOCK_DATA.USER.image} alt="profile-image" />
         <img src={icPlus} />

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,12 @@
+import { BoardInfo } from '../types';
+import { mockService } from './mock';
+
+export const service = getAPIMethod();
+
+function getAPIMethod() {
+  return mockService();
+}
+
+export interface Service {
+  getBoardDetail(boardID: string): Promise<Pick<BoardInfo, 'title' | 'savedTime'>>;
+}

--- a/src/services/mock/index.ts
+++ b/src/services/mock/index.ts
@@ -1,0 +1,13 @@
+import { Service } from '..';
+import { getRelativeTime } from '../../utils/time';
+
+export function mockService(): Service {
+  const getBoardDetail = async () => {
+    await wait(2000);
+    return { title: '개', savedTime: getRelativeTime(new Date('2022-05-27T15:11:44.933Z')) };
+  };
+
+  return { getBoardDetail };
+}
+
+const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASEURL = '3.39.22.91:8000';
+const BASEURL = 'http://3.39.22.91:8000';
 
 const baseHeaders = {
   Accept: `*/*`,

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -1,0 +1,83 @@
+import axios from 'axios';
+
+const BASEURL = '3.39.22.91:8000';
+
+const baseHeaders = {
+  Accept: `*/*`,
+  'Content-Type': `application/json`,
+};
+
+const baseMultipartHeaders = {
+  Accept: `*/*`,
+  'Content-Type': `multipart/form-data`,
+};
+
+interface Request {
+  url: string;
+  headers?: object;
+  method: 'get' | 'post' | 'put' | 'delete';
+}
+
+interface RequestWithParams extends Request {
+  params?: object;
+}
+
+interface RequestWithData extends Request {
+  data?: object;
+  type?: 'multipart' | 'json';
+}
+
+const sendRequest = ({ url, params, method, headers }: RequestWithParams) => {
+  return axios[method](BASEURL + url, {
+    headers: { ...baseHeaders, ...headers },
+    params,
+  }).then((response) => {
+    return { ...response.data, axiosStatus: response.status };
+  });
+};
+
+const sendRequestWithData = ({ url, data, method, headers, type }: RequestWithData) => {
+  return axios[method](BASEURL + url, data, {
+    headers: { ...(type === 'json' ? baseHeaders : baseMultipartHeaders), ...headers },
+  }).then((response) => {
+    return response.data;
+  });
+};
+
+const sendRequestForDelete = ({ url, data, headers }: Omit<RequestWithData, 'method'>) => {
+  return axios
+    .delete(BASEURL + url, {
+      headers: { ...baseHeaders, ...headers },
+      data: data,
+    })
+    .then((response) => {
+      return response.data;
+    });
+};
+
+export const API = {
+  get: ({ url, params, headers }: Omit<RequestWithParams, 'method'>) =>
+    sendRequest({ url, params, method: 'get', headers }),
+  post: ({ url, data, headers, type }: Omit<RequestWithData, 'method'>) =>
+    sendRequestWithData({
+      url,
+      data,
+      method: 'post',
+      headers,
+      type: type ?? 'json',
+    }),
+  put: ({ url, data, headers, type }: Omit<RequestWithData, 'method'>) =>
+    sendRequestWithData({
+      url,
+      data,
+      method: 'put',
+      headers,
+      type: type ?? 'json',
+    }),
+  delete: ({ url, data, headers }: Omit<RequestWithData, 'method'>) =>
+    sendRequestForDelete({
+      url,
+      data,
+      headers,
+    }),
+};

--- a/src/services/remote/index.ts
+++ b/src/services/remote/index.ts
@@ -1,0 +1,18 @@
+import { Service } from '..';
+import { getRelativeTime } from '../../utils/time';
+import { API } from './base';
+
+export function remoteService(): Service {
+  const getBoardDetail = async (boardID: string) => {
+    const response = await API.get({ url: `/board/${boardID}` });
+    console.log(getRelativeTime(new Date(response.data.createdAt)));
+    if (response.success)
+      return {
+        title: response.data.boardName,
+        savedTime: getRelativeTime(new Date(response.data.createdAt)),
+      };
+    else throw '서버 통신 실패';
+  };
+
+  return { getBoardDetail };
+}

--- a/src/services/remote/index.ts
+++ b/src/services/remote/index.ts
@@ -5,7 +5,6 @@ import { API } from './base';
 export function remoteService(): Service {
   const getBoardDetail = async (boardID: string) => {
     const response = await API.get({ url: `/board/${boardID}` });
-    console.log(getRelativeTime(new Date(response.data.createdAt)));
     if (response.success)
       return {
         title: response.data.boardName,

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,27 @@
+export const getRelativeTime = (time: Date) => {
+  const now = new Date();
+  const createdAt = new Date(time);
+
+  const seconds = 1;
+  const minute = seconds * 60;
+  const hour = minute * 60;
+  const day = hour * 24;
+
+  const cumulativeTime = Math.trunc((now.getTime() - createdAt.getTime()) / 1000);
+
+  let relativeTime = '';
+  if (cumulativeTime < seconds) {
+    relativeTime = '방금';
+  } else if (cumulativeTime < minute) {
+    relativeTime = cumulativeTime + '초';
+  } else if (cumulativeTime < hour) {
+    relativeTime = Math.trunc(cumulativeTime / minute) + '분';
+  } else if (cumulativeTime < day) {
+    relativeTime = Math.trunc(cumulativeTime / hour) + '시간';
+  } else if (cumulativeTime < day * 15) {
+    relativeTime = Math.trunc(cumulativeTime / day) + '일';
+  } else {
+    relativeTime = Math.trunc(cumulativeTime / (day * 7)) + '주';
+  }
+  return relativeTime;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,6 +2657,14 @@ axe-core@^4.3.5:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz"
@@ -4483,6 +4491,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.1"
   resolved "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.1.tgz"
@@ -4506,6 +4519,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
## ⛓ Related Issues
- close #30 

## 📋 작업 내용
- [x] 상대 시간 유틸 함수 만들기
- [x] axios 요청 추상화 하기
- [x] 데이터 프로바이더 만들어서 보드 조회에 적용하기
  
## 📌 PR Point
### 상대 시간 유틸 함수(getRelativeTime)
Date 객체를 인자로 받아 상대 시간 string을 리턴해주는 함수입니다
([UI에서 날짜, 시간 표기하는 방식 -> 상대 시간/절대 시간](https://kimtoma.com/2021/01/02/how-to-display-the-date-and-time-in-ui/))
```ts
getRelativeTime(new Date('2022-05-27T15:11:44.933Z')) // 5.30 pm1:30 기준 return '2일'
```
### axios 요청 추상화

`API` 객체를 통해 axios 요청을 간결하게 할 수 있도록 했습니다
어떤 메소드인지, url은 무엇인지 등등 꼭 필요한 정보만 알면 api 요청을 할 수 있습니다!

```ts
// get
API.get({ url: `/board/${boardID}` });
// post
API.post({ url: '/board', data: {
    "boardName" : "물고기",
    "updateTime" : "0",
    "writer": "6290e84b9d0e342c69c78f0e"
} });
```

### 데이터 프로바이더
services/index.ts의 `getAPIMethod`의 return 값만 바꾸면 mock 요청을 할지 remote 요청을 할지 설정할 수 있습니다
컴포넌트에선 현재 api를 mock으로 연결했는지 remote인지 몰라도 되게끔 + 자세한 api 요청 코드를 몰라도 필요한 정보를 주고 받을 수 있도록 한 것입니다!
그리고 api 요청 함수를 거치면서 response를 정제해주기 때문에 서버에서 어떤 변수명으로 값을 보내주든 컴포넌트 코드에 영향이 없습니다

services/index.ts
```ts
import { BoardInfo } from '../types';
import { mockService } from './mock';

export const service = getAPIMethod();

function getAPIMethod() {
  return mockService(); // 여기만 remoteService로 갈아치우면 remote 요청
}

export interface Service {
  getBoardDetail(boardID: string): Promise<Pick<BoardInfo, 'title' | 'savedTime'>>;
}
```
Service 인터페이스에 api 요청 함수들을 추가하고 mock/index.ts와 remote/index.ts에 각각 함수를 작성해놓습니다

mock/index.ts
```ts
import { Service } from '..';
import { getRelativeTime } from '../../utils/time';

export function mockService(): Service {
  const getBoardDetail = async () => {
    await wait(2000);
    return { title: '개', savedTime: getRelativeTime(new Date('2022-05-27T15:11:44.933Z')) };
  };

  return { getBoardDetail };
}

const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));

```

remote.ts
```ts
import { Service } from '..';
import { getRelativeTime } from '../../utils/time';
import { API } from './base';

export function remoteService(): Service {
  const getBoardDetail = async (boardID: string) => {
    const response = await API.get({ url: `/board/${boardID}` });
    if (response.success)
      return {
        title: response.data.boardName,
        savedTime: getRelativeTime(new Date(response.data.createdAt)),
      };
    else throw '서버 통신 실패';
  };

  return { getBoardDetail };
}

```

실제로 컴포넌트에서 요청을 할 때에는 아래와 같이 써놓으면 데이터 프로바이더 단에서 mockService를 쓰고 있든 remoteService를 쓰고 있든 정상 작동합니다
따라서 api가 나와있든 나와있지 않든 컴포넌트 구현에 문제가 없게 됩니다🙌

Board.tsx
```ts
생략
const getBoardInfo = async () => {
    if (!id) return navigate('/');
    const response = await service.getBoardDetail(id);
    response && setBoardInfo(response);
  };
  useEffect(() => {
    getBoardInfo();
  }, []);
생략
```
## 👀 스크린샷 / GIF / 링크
<img width="335" alt="image" src="https://user-images.githubusercontent.com/73823388/170917242-9725364f-1ef7-4711-af32-610254ca2b83.png">


## 🔬 Reference
- https://kimtoma.com/2021/01/02/how-to-display-the-date-and-time-in-ui/
- [너가소개서의 멋진 infrastructrue](https://github.com/Neogasogaeseo/Naega-Web/tree/dev/src/infrastructure)
