### PR TITLE
마이페이지 유저정보 GET api 작성 및 적용

### DIFF
--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -17,7 +17,6 @@ export default function Board() {
   const navigate = useNavigate();
 
   const getBoardInfo = async () => {
-    console.log(id);
     if (!id) return navigate('/');
     const response = await service.getBoardDetail(id);
     response && setBoardInfo(response);

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -17,6 +17,7 @@ export default function Board() {
   const navigate = useNavigate();
 
   const getBoardInfo = async () => {
+    console.log(id);
     if (!id) return navigate('/');
     const response = await service.getBoardDetail(id);
     response && setBoardInfo(response);

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -4,16 +4,12 @@ import { IcSearch, IcPlus, icSetting } from '../assets/icons';
 import { BoardInfo, BoardPinInfo } from '../types';
 import { FONT_STYLES } from '../styles/font';
 import { COLOR } from '../styles/color';
+import { service } from '../services';
+import { UserInfo } from '../types';
+import { MOCK_DATA } from '../services/mock/data';
 import BoardList from '../components/BoardList';
 import MyPageNavigation from '../components/MyPageNavigation';
 import BottomSheet from '../components/BottomSheet';
-
-interface MyPageUserInfo {
-  userId: string;
-  nickname: string;
-  followerCnt: number;
-  followingCnt: number;
-}
 
 export default function MyPage() {
   const boardList: BoardPinInfo[] = [
@@ -43,15 +39,22 @@ export default function MyPage() {
     { id: 1, title: '바닷가', boardList: boardList, savedTime: '방금' },
     { id: 2, title: '제주도', boardList: boardList, savedTime: '방금' },
   ];
-  const [userInfo, setUserInfo] = useState<MyPageUserInfo>();
+  const [userInfo, setUserInfo] =
+    useState<Pick<UserInfo, 'userId' | 'nickname' | 'followingCnt' | 'followerCnt'>>();
   const [open, setOpen] = useState<boolean>(false);
 
   const toggleModal = () => {
     setOpen((prev: boolean) => !prev);
   };
 
+  const getUserInfo = async () => {
+    const id = MOCK_DATA.MYPAGE_USER.id;
+    const response = await service.getUserInfo(id);
+    response && setUserInfo(response);
+  };
+
   useEffect(() => {
-    setUserInfo({ userId: 'cheeze123', nickname: '치즈', followerCnt: 36, followingCnt: 54 });
+    getUserInfo();
   }, []);
 
   return (

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -39,8 +39,7 @@ export default function MyPage() {
     { id: 1, title: '바닷가', boardList: boardList, savedTime: '방금' },
     { id: 2, title: '제주도', boardList: boardList, savedTime: '방금' },
   ];
-  const [userInfo, setUserInfo] =
-    useState<Pick<UserInfo, 'userId' | 'nickname' | 'followingCnt' | 'followerCnt'>>();
+  const [userInfo, setUserInfo] = useState<Omit<UserInfo, 'id'>>();
   const [open, setOpen] = useState<boolean>(false);
 
   const toggleModal = () => {
@@ -48,8 +47,8 @@ export default function MyPage() {
   };
 
   const getUserInfo = async () => {
-    const id = MOCK_DATA.MYPAGE_USER.id;
-    const response = await service.getUserInfo(id);
+    const userId = MOCK_DATA.USER.userId;
+    const response = await service.getUserInfo(userId);
     response && setUserInfo(response);
   };
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,7 +9,5 @@ function getAPIMethod() {
 
 export interface Service {
   getBoardDetail(boardID: string): Promise<Pick<BoardInfo, 'title' | 'savedTime'>>;
-  getUserInfo(
-    userId: string,
-  ): Promise<Pick<UserInfo, 'userId' | 'nickname' | 'followingCnt' | 'followerCnt'>>;
+  getUserInfo(userId: string): Promise<Omit<UserInfo, 'id'>>;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,4 @@
-import { BoardInfo } from '../types';
+import { BoardInfo, UserInfo } from '../types';
 import { mockService } from './mock';
 
 export const service = getAPIMethod();
@@ -9,4 +9,7 @@ function getAPIMethod() {
 
 export interface Service {
   getBoardDetail(boardID: string): Promise<Pick<BoardInfo, 'title' | 'savedTime'>>;
+  getUserInfo(
+    userId: string,
+  ): Promise<Pick<UserInfo, 'userId' | 'nickname' | 'followingCnt' | 'followerCnt'>>;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,10 +1,10 @@
 import { BoardInfo, UserInfo } from '../types';
-import { mockService } from './mock';
+import { remoteService } from './remote';
 
 export const service = getAPIMethod();
 
 function getAPIMethod() {
-  return mockService();
+  return remoteService();
 }
 
 export interface Service {

--- a/src/services/mock/data.ts
+++ b/src/services/mock/data.ts
@@ -4,13 +4,11 @@ export const MOCK_DATA = {
     userID: 'cheeze123',
     image:
       'https://images.unsplash.com/photo-1566496875470-68ada46a38c5?crop=entropy&cs=tinysrgb&fm=jpg&ixlib=rb-1.2.1&q=80&raw_url=true&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170',
+    userId: 'cheeze123',
   },
   BOARD: {
     id: 1,
     name: '바닷가',
     pinList: [],
-  },
-  MYPAGE_USER: {
-    id: '62904389d917606ee855ee04',
   },
 };

--- a/src/services/mock/data.ts
+++ b/src/services/mock/data.ts
@@ -10,4 +10,7 @@ export const MOCK_DATA = {
     name: '바닷가',
     pinList: [],
   },
+  MYPAGE_USER: {
+    id: '62904389d917606ee855ee04',
+  },
 };

--- a/src/services/mock/index.ts
+++ b/src/services/mock/index.ts
@@ -7,7 +7,16 @@ export function mockService(): Service {
     return { title: '개', savedTime: getRelativeTime(new Date('2022-05-27T15:11:44.933Z')) };
   };
 
-  return { getBoardDetail };
+  const getUserInfo = async () => {
+    await wait(2000);
+    return {
+      userId: 'cheeze123',
+      nickname: '치즈',
+      followingCnt: 54,
+      followerCnt: 36,
+    };
+  };
+  return { getBoardDetail, getUserInfo };
 }
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASEURL = 'http://3.39.22.91:8000';
+const BASEURL = 'https://sopterest.ml';
 
 const baseHeaders = {
   Accept: `*/*`,

--- a/src/services/remote/index.ts
+++ b/src/services/remote/index.ts
@@ -13,5 +13,17 @@ export function remoteService(): Service {
     else throw '서버 통신 실패';
   };
 
-  return { getBoardDetail };
+  const getUserInfo = async (userId: string) => {
+    const response = await API.get({ url: `/user/${userId}` });
+    if (response.success)
+      return {
+        userId: response.data.userId,
+        nickname: response.data.nickname,
+        followerCnt: response.data.followerCnt,
+        followingCnt: response.data.followingCnt,
+      };
+    else throw '서버 통신 실패';
+  };
+
+  return { getBoardDetail, getUserInfo };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,3 +15,11 @@ export interface Toast {
   mode: ToastMode;
   message: string;
 }
+
+export interface UserInfo {
+  id: string;
+  userId: string;
+  nickname: string;
+  followingCnt: number;
+  followerCnt: number;
+}


### PR DESCRIPTION
## ⛓ Related Issues
- close #32

## 📋 작업 내용
- [x] ~ 마이페이지 유저정보 GET api 작성 및 적용

## 📌 PR Point
- 어떤 부분에 리뷰어가 집중해야 하는지
1. 유저 상세 조회 시 ~/user/:userId 경로로 userId를 params로 보내주어야 하는데, 
```
MYPAGE_USER: {
    userId: 'cheese123',
  },
``` 
이 때 mock data에 위와 같이 데이터를 만들어놓고 써도 될까요? 만든 이유는... userId를 넘겨주려면 로그인 정보같은 걸 알고 있어야 하는데 로그인 기능이 없으니 임의로 하나 만들어주어야 할 것 같아서? 입니다.

2. types/index.ts에 `UserInfo` interface를 하나 더 만들었습니다. 만든 이유는 `getUserInfo` 함수의 반환 타입을 정해주기 위해서...입니다. services/index.ts에서 `getUserInfo` 에서 Pick을 이용해서 id 빼고 다 사용하고 있는데, 이럴거면 그냥 Pick 안 쓰고 `Promise<UserInfo>`만 써주는 게 좋을까요?


## 👀 스크린샷 / GIF / 링크

https://user-images.githubusercontent.com/66051416/171147886-6f2427aa-7150-451e-84fc-40f1066fea59.mp4

## 🔬 Reference
