### PR TITLE
보드 생성 페이지에 post api 연동

### DIFF
--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -65,7 +65,6 @@ export default function BoardForm() {
 
 const StWrapper = styled.div`
   width: 100%;
-  height: 100%; // 이거 지워야 함
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -3,8 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IcBack } from '../assets/icons';
 import BoardFormToast from '../components/BoardFormToast';
+import { service } from '../services';
 import { COLOR } from '../styles/color';
 import { FONT_STYLES } from '../styles/font';
+import { CreateBoardBody } from '../types';
 
 export default function BoardForm() {
   const navigate = useNavigate();
@@ -28,8 +30,15 @@ export default function BoardForm() {
     setTitle(e.target.value);
   };
 
-  const goBoard = () => {
-    if (title.length > 0) navigate(`/board/id들어갈곳`);
+  const createBoard = async () => {
+    const body: CreateBoardBody = {
+      boardName: title,
+      updateTime: '0',
+      writer: '6290e84b9d0e342c69c78f0e',
+    };
+    const response = await service.createBoard(body);
+
+    if (title.length > 0) navigate(`/board/${response.boardId}`);
   };
 
   const goBack = () => {
@@ -41,7 +50,7 @@ export default function BoardForm() {
       <StHeaderWrapper>
         <StIcBack onClick={goBack} />
         <StHeaderTitle>보드 만들기</StHeaderTitle>
-        <StCreateButton isActive={isActive} onClick={goBoard}>
+        <StCreateButton isActive={isActive} onClick={createBoard}>
           만들기
         </StCreateButton>
       </StHeaderWrapper>
@@ -56,7 +65,7 @@ export default function BoardForm() {
 
 const StWrapper = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100%; // 이거 지워야 함
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/BoardForm.tsx
+++ b/src/pages/BoardForm.tsx
@@ -6,7 +6,7 @@ import BoardFormToast from '../components/BoardFormToast';
 import { service } from '../services';
 import { COLOR } from '../styles/color';
 import { FONT_STYLES } from '../styles/font';
-import { CreateBoardBody } from '../types';
+import { BoardCreateRequestBody } from '../types';
 
 export default function BoardForm() {
   const navigate = useNavigate();
@@ -31,7 +31,7 @@ export default function BoardForm() {
   };
 
   const createBoard = async () => {
-    const body: CreateBoardBody = {
+    const body: BoardCreateRequestBody = {
       boardName: title,
       updateTime: '0',
       writer: '6290e84b9d0e342c69c78f0e',

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,10 +1,10 @@
 import { BoardInfo, BoardID, CreateBoardBody } from '../types';
-import { mockService } from './mock';
+import { remoteService } from './remote';
 
 export const service = getAPIMethod();
 
 function getAPIMethod() {
-  return mockService();
+  return remoteService();
 }
 
 export interface Service {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,4 @@
-import { BoardInfo } from '../types';
+import { BoardInfo, BoardID, CreateBoardBody } from '../types';
 import { mockService } from './mock';
 
 export const service = getAPIMethod();
@@ -9,4 +9,5 @@ function getAPIMethod() {
 
 export interface Service {
   getBoardDetail(boardID: string): Promise<Pick<BoardInfo, 'title' | 'savedTime'>>;
+  createBoard(body: CreateBoardBody): Promise<BoardID>;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,4 @@
-import { BoardInfo, BoardID, CreateBoardBody } from '../types';
+import { BoardInfo, BoardCreateRequestBody } from '../types';
 import { remoteService } from './remote';
 
 export const service = getAPIMethod();
@@ -9,5 +9,8 @@ function getAPIMethod() {
 
 export interface Service {
   getBoardDetail(boardID: string): Promise<Pick<BoardInfo, 'title' | 'savedTime'>>;
-  createBoard(body: CreateBoardBody): Promise<BoardID>;
+  createBoard(body: BoardCreateRequestBody): Promise<{
+    boardId: string;
+    isSuccess: boolean;
+  }>;
 }

--- a/src/services/mock/index.ts
+++ b/src/services/mock/index.ts
@@ -7,7 +7,12 @@ export function mockService(): Service {
     return { title: '개', savedTime: getRelativeTime(new Date('2022-05-27T15:11:44.933Z')) };
   };
 
-  return { getBoardDetail };
+  const createBoard = async () => {
+    await wait(2000);
+    return { boardId: '6294a5c795d4a7e07140547a' };
+  };
+
+  return { getBoardDetail, createBoard };
 }
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));

--- a/src/services/mock/index.ts
+++ b/src/services/mock/index.ts
@@ -9,7 +9,7 @@ export function mockService(): Service {
 
   const createBoard = async () => {
     await wait(2000);
-    return { boardId: '6294a5c795d4a7e07140547a' };
+    return { boardId: '6294a5c795d4a7e07140547a', isSuccess: true };
   };
 
   return { getBoardDetail, createBoard };

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASEURL = 'http://3.39.22.91:8000';
+const BASEURL = 'https://sopterest.ml';
 
 const baseHeaders = {
   Accept: `*/*`,

--- a/src/services/remote/index.ts
+++ b/src/services/remote/index.ts
@@ -1,4 +1,5 @@
 import { Service } from '..';
+import { CreateBoardBody } from '../../types';
 import { getRelativeTime } from '../../utils/time';
 import { API } from './base';
 
@@ -13,5 +14,14 @@ export function remoteService(): Service {
     else throw '서버 통신 실패';
   };
 
-  return { getBoardDetail };
+  const createBoard = async (body: CreateBoardBody) => {
+    const response = await API.post({ url: `/board`, data: body });
+    if (response.success)
+      return {
+        boardId: response.data._id,
+      };
+    else throw '서버 통신 실패';
+  };
+
+  return { getBoardDetail, createBoard };
 }

--- a/src/services/remote/index.ts
+++ b/src/services/remote/index.ts
@@ -1,5 +1,5 @@
 import { Service } from '..';
-import { CreateBoardBody } from '../../types';
+import { BoardCreateRequestBody } from '../../types';
 import { getRelativeTime } from '../../utils/time';
 import { API } from './base';
 
@@ -14,11 +14,12 @@ export function remoteService(): Service {
     else throw '서버 통신 실패';
   };
 
-  const createBoard = async (body: CreateBoardBody) => {
+  const createBoard = async (body: BoardCreateRequestBody) => {
     const response = await API.post({ url: `/board`, data: body });
     if (response.success)
       return {
         boardId: response.data._id,
+        isSuccess: true,
       };
     else throw '서버 통신 실패';
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,12 +16,8 @@ export interface Toast {
   message: string;
 }
 
-export type CreateBoardBody = {
+export type BoardCreateRequestBody = {
   boardName: string;
   updateTime: string;
   writer: string;
-};
-
-export type BoardID = {
-  boardId: string;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,3 +15,13 @@ export interface Toast {
   mode: ToastMode;
   message: string;
 }
+
+export type CreateBoardBody = {
+  boardName: string;
+  updateTime: string;
+  writer: string;
+};
+
+export type BoardID = {
+  boardId: string;
+};


### PR DESCRIPTION
## ⛓ Related Issues
- close #35 

## 📋 작업 내용
- [x] post api 연동
- [x] mock 데이터 적용해보기

## 📌 PR Point
- BoardId 와 CreateBoardBody 타입을 잘 명시 했을까요? BoardId가 { boardId : string} 이라 타입을 명시하지 않는 게 나을지 고민이 됩니다!
- mock 을 쓸때, 포스트 같은 경우는 api 명세서에 나와 있는 반환 값만 반환을 해주면 되나요? 따로 mock data에 추가한다던가 작업은 하지 않아도 되나요??
- remote 와 mock 둘다 테스트 한 결과, 잘 작동 했습니다!

## 👀 스크린샷 / GIF / 링크
![스크린샷 2022-06-01 오후 1 48 28](https://user-images.githubusercontent.com/42725903/171329966-5810a81f-bf47-4049-90a1-324c95392fc6.png)
![스크린샷 2022-06-01 오후 1 49 28](https://user-images.githubusercontent.com/42725903/171329996-a7856dc4-b746-48e6-a319-397f3ddca949.png)

